### PR TITLE
Fixes #153 - update to 'skeleton' import

### DIFF
--- a/frontend/src/components/MeanTableDownload/index.js
+++ b/frontend/src/components/MeanTableDownload/index.js
@@ -9,7 +9,7 @@ import {
   DialogActions
 } from '@mui/material'
 import filesize from 'filesize';
-import Skeleton from '@mui/lab/Skeleton';
+import { Skeleton } from '@mui/material';
 import { useQuery } from 'react-query'
 import { getMeanTableDownloadInfo } from '../../services/api';
 import GenericError from '../Alerts/GenericError';


### PR DESCRIPTION
`Skeleton` import was obsolete, it was necessary to add the updated import format `{ Skeleton }`. 
 When doing this update the warnings were resolved!